### PR TITLE
Update to bindgen that doesn't crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ paste = "1.0.7"
 rtt-target = "0.3.1"
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.70.1"
 cc = "1.0"
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
Bindgen would crash with the following error message on SDK version 6.0.22:

```
thread 'main' panicked at /Users/niklasdusenlund/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.59.2/src/ir/context.rs:878:9:
"enum_(unnamed_at_/opt/DA145xx_SDK/6_0_22_1401/sdk/platform/core_modules/common/api/co_bt_h_1290_1)" is not a valid Ident
```