### PR TITLE
Add support for static header fns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ paste = "1.0.7"
 rtt-target = "0.3.1"
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = {version="0.70.1", features=["experimental"]}
 cc = "1.0"
 lazy_static = "1.4.0"
 

--- a/build.rs
+++ b/build.rs
@@ -432,6 +432,7 @@ fn generate_bindings(
 ) {
     let mut builder = bindgen::Builder::default()
         .header("bindings.h")
+        .wrap_static_fns(true)
         .ctypes_prefix("cty")
         .use_core()
         .size_t_is_usize(true)
@@ -507,6 +508,15 @@ fn compile_sdk(
 
     for file in sdk_c_sources {
         cc_builder = cc_builder.file(translate_path(file));
+    }
+
+    // Bindgen creates a C-file for static fns
+    {
+        let mut path = PathBuf::from(env::temp_dir());
+        path.push("bindgen");
+        path.push("extern.c");
+        cc_builder.file(translate_path(path.to_str().unwrap()));
+        cc_builder.include(translate_path(&env::var("CARGO_MANIFEST_DIR").unwrap()));
     }
 
     cc_builder.compile("sdk");


### PR DESCRIPTION
Fixes the following build issue:

```
error[E0425]: cannot find function `otp_cs_get_adc_trim_val` in module `crate::bindings`
  --> da14531-sdk/src/platform/mod.rs:10:39
   |
10 |             unsafe { crate::bindings::otp_cs_get_adc_trim_val() }
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^ not found in `crate::bindings`
```